### PR TITLE
Change from BearerAuth to API Key Auth

### DIFF
--- a/conversion.md
+++ b/conversion.md
@@ -1,0 +1,15 @@
+A conversion of the OpenAI OpenAPI to TypeSpec.
+
+There are some deltas:
+
+### Changes to API Semantics:
+
+- Many things are missing defaults (mostly due to bug where we can't set null defaults)
+- Error responses have been added.
+- Where known, the `object` property's type is narrowed from string to the constant value it will always be
+
+### Changes to API metadata or OpenAPI format
+
+- Much of the x-oaiMeta entries have not been added.
+- In some cases, new schemas needed to be defined in order to be defined in TypeSpec (e.g. because the constraints could not be added to a model property with a heterogeneous type)
+- There is presently no way to set `title`

--- a/main.tsp
+++ b/main.tsp
@@ -27,5 +27,5 @@ using TypeSpec.Http;
   },
   version: "2.0.0",
 })
-@useAuth(ApiKeyAuth<ApiKeyLocation.query, "AUTHORIZATION">)
+@useAuth(ApiKeyAuth<ApiKeyLocation.header, "AUTHORIZATION">)
 namespace OpenAI;

--- a/main.tsp
+++ b/main.tsp
@@ -27,5 +27,5 @@ using TypeSpec.Http;
   },
   version: "2.0.0",
 })
-@useAuth(BearerAuth)
+@useAuth(ApiKeyAuth<ApiKeyLocation.query, "AUTHORIZATION">)
 namespace OpenAI;

--- a/readme.md
+++ b/readme.md
@@ -1,15 +1,3 @@
-A conversion of the OpenAI OpenAPI to TypeSpec.
+# OpenAPI spec for the OpenAI API
 
-There are some deltas:
-
-### Changes to API Semantics:
-
-- Many things are missing defaults (mostly due to bug where we can't set null defaults)
-- Error responses have been added.
-- Where known, the `object` property's type is narrowed from string to the constant value it will always be
-
-### Changes to API metadata or OpenAPI format
-
-- Much of the x-oaiMeta entries have not been added.
-- In some cases, new schemas needed to be defined in order to be defined in TypeSpec (e.g. because the constraints could not be added to a model property with a heterogeneous type)
-- There is presently no way to set `title`
+This repository contains an [OpenAPI](https://www.openapis.org/) specification for the [OpenAI API](https://platform.openai.com/docs/api-reference).


### PR DESCRIPTION
The original OpenAI API definition [defines their auth policy as API Key](https://github.com/openai/openai-openapi/blob/master/openapi.yaml#L4168), so changing the TypeSpec to do the same.